### PR TITLE
fix selection

### DIFF
--- a/HySideScrollingImagePicker/HySideScrollingImagePicker.m
+++ b/HySideScrollingImagePicker/HySideScrollingImagePicker.m
@@ -283,21 +283,21 @@
     
     HCollectionViewCell *cell = (HCollectionViewCell *)[self.CollectionView cellForItemAtIndexPath:indexPath];
     SideScrollingCheckCell *checkmarkView = [self.indexPathToCheckViewTable objectForKey:indexPath];
-    
+    ALAsset *asset = self.allArr[(NSUInteger) indexPath.row];
     if (!_isMultipleSelection) {
         
         // Manage internal selection state
-        if ([self.selectedIndexes containsObject:cell.imageView.image]) {
-            [self.selectedIndexes removeObject:cell.imageView.image];
+        if ([self.selectedIndexes containsObject:asset]) {
+            [self.selectedIndexes removeObject:asset];
             [cell setSelected:NO];
             [checkmarkView setChecked:NO];
         } else {
-            [self.selectedIndexes addObject:cell.imageView.image];
+            [self.selectedIndexes addObject:asset];
             [cell setSelected:YES];
             [checkmarkView setChecked:YES];
         }
     }else{
-        [self.selectedIndexes addObject:cell.imageView.image];
+        [self.selectedIndexes addObject:asset];
         [cell setSelected:YES];
         [checkmarkView setChecked:YES];
         typeof(self) __weak weak = self;


### PR DESCRIPTION
由于UICollection的重用机制,cell的imageView可能已经不是原来的imageView,所以可以用数据源去判断是否已选择过.当然,block里返回的NSArray是ALAsset,取到原图也方便.
